### PR TITLE
import font files

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,12 @@ EmberCLIBootstrap.prototype.included = function included(app) {
       app.import(javascriptsPath + fileName + envModifier + '.js');
     }
   })
+
+  // Import fonts
+  app.import('vendor/bootstrap/dist/fonts/glyphicons-halflings-regular.eot', { destDir: 'fonts' });
+  app.import('vendor/bootstrap/dist/fonts/glyphicons-halflings-regular.svg', { destDir: 'fonts' });
+  app.import('vendor/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf', { destDir: 'fonts' });
+  app.import('vendor/bootstrap/dist/fonts/glyphicons-halflings-regular.woff', { destDir: 'fonts' });
 };
 
 module.exports = EmberCLIBootstrap;


### PR DESCRIPTION
Brings in the font files as well. The css is looking for them at /fonts, but it would probably be neater at some point to put them at /assets/fonts and run the css file through a replace-string filter to update the path.
