### PR TITLE
[BUG] This fixes issue #11. This occurs when no options are specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ EmberCLIBootstrap.prototype.included = function included(app) {
   var options         = app.options['ember-cli-bootstrap'] || {};
   var bootstrapPath   = 'vendor/bootstrap/dist/'
   var javascriptsPath = 'node_modules/ember-cli-bootstrap/vendor/ember-addons.bs_for_ember/dist/js/';
-  var jsFiles         = (options.components) ? options.components : fs.readdirSync(javascriptsPath);
+  var jsFiles         = options.components ? options.components : fs.readdirSync(javascriptsPath);
 
   // Import css from bootstrap
   app.import(bootstrapPath + 'css/bootstrap-theme.css');


### PR DESCRIPTION
Fixes issue #11 (when running on new ember-cli 0.0.42). When no options are defined in the ember-cli project's brocfile.js, then the options object will be undefined. So ensure that the options object exists before looking for its components or import properties.

Made these small changes and verified that Hello World "{{bs-alert message="A self destroyable hello world message!" type="info" dismissAfter=2 fade=true}}" now works in my ember-cli project after this change. 
