### PR TITLE
Update addon to use new style of index.js

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "vendor"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-bower_components/
+vendor/
 node_modules/
 npm-debug.log

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
   "name": "ember-cli-bootstrap",
   "dependencies": {
+    "bootstrap": "~3.1.1",
     "ember-addons.bs_for_ember": "~0.7.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,61 +1,44 @@
-'use strict';
-
-var path = require('path');
 var fs   = require('fs');
+var path = require('path');
 
-function EmberCLIBootstrap(project) {
-  this.project = project;
-  this.name    = 'Ember CLI Bootstrap';
-}
+module.exports = {
+  name: 'ember-cli-bootstrap',
+  included: function included(app) {
+    this.app = app;
 
-function unwatchedTree(dir) {
-  return {
-    read:    function() { return dir; },
-    cleanup: function() { }
-  };
-}
+    var emberCLIVersion = app.project.emberCLIVersion();
+    if (emberCLIVersion < '0.0.41') {
+      throw new Error('ember-cli-bootstrap requires ember-cli version 0.0.41 or greater.\n');
+    }
 
-EmberCLIBootstrap.prototype.treeFor = function treeFor(name) {
-  var treePath = path.join('node_modules/ember-cli-bootstrap', name);
+    var options         = app.options['ember-cli-bootstrap'] || {};
+    var modulePath      = path.relative(app.project.root, __dirname);
+    var bootstrapPath   = 'vendor/bootstrap/dist/';
+    var emberBsPath     = 'vendor/ember-addons.bs_for_ember/dist'
+    var javascriptsPath = path.join(emberBsPath, 'js');
+    var jsFiles         = options.components ? options.components : fs.readdirSync(path.join(modulePath, javascriptsPath));
 
-  if (fs.existsSync(treePath)) {
-    return unwatchedTree(treePath);
+    // Import css from bootstrap
+    app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css'));
+    app.import(path.join(bootstrapPath, 'css/bootstrap.css'));
+    app.import(path.join(emberBsPath, 'css/bs-growl-notifications.min.css'));
+
+    // Import javascript files
+    app.import(path.join(javascriptsPath, 'bs-core.max.js')); // Import bs-core first
+
+    jsFiles.forEach(function(file) {
+      var fileName = file.split('.')[0];
+      app.import(path.join(javascriptsPath, fileName + '.max.js'));
+    });
+
+    if (options.importBootstrapJS) {
+      app.import(path.join(bootstrapPath, 'js/bootstrap.js'));
+    }
+
+    // Import glyphicons
+    app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.eot'), { destDir: '/fonts' });
+    app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.svg'), { destDir: '/fonts' });
+    app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.ttf'), { destDir: '/fonts' });
+    app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.woff'), { destDir: '/fonts' });
   }
 };
-
-EmberCLIBootstrap.prototype.included = function included(app) {
-  var emberCLIVersion = app.project.emberCLIVersion();
-  if (emberCLIVersion < '0.0.41') {
-    throw new Error('ember-cli-bootstrap requires ember-cli version 0.0.41 or greater.\n');
-  }
-
-  var options         = app.options['ember-cli-bootstrap'] || {};
-  var bootstrapPath   = '../../node_modules/ember-cli-bootstrap/node_modules/bootstrap/dist/'
-  var javascriptsPath = '../../node_modules/ember-cli-bootstrap/vendor/ember-addons.bs_for_ember/dist/js/';
-  var jsFiles         = options.components ? options.components : fs.readdirSync('node_modules/ember-cli-bootstrap/vendor/ember-addons.bs_for_ember/dist/js/');
-
-  // Import css
-  app.import(bootstrapPath + 'css/bootstrap-theme.css');
-  app.import(bootstrapPath + 'css/bootstrap.css');
-  app.import('vendor/ember-addons.bs_for_ember/dist/css/bs-growl-notifications.min.css');
-
-  // Import javascript files
-  app.import(javascriptsPath + 'bs-core.max.js'); // Import bs-core first
-
-  jsFiles.forEach(function(file) {
-    var fileName = file.split('.')[0];
-    app.import(javascriptsPath + fileName + '.max.js');
-  });
-
-  if (options.importBootstrapJS) {
-    app.import(bootstrapPath + 'js/bootstrap.js');
-  }
-
-  // Import glyphicons
-  app.import(bootstrapPath + 'fonts/glyphicons-halflings-regular.eot', { destDir: '/fonts' });
-  app.import(bootstrapPath + 'fonts/glyphicons-halflings-regular.svg', { destDir: '/fonts' });
-  app.import(bootstrapPath + 'fonts/glyphicons-halflings-regular.ttf', { destDir: '/fonts' });
-  app.import(bootstrapPath + 'fonts/glyphicons-halflings-regular.woff', { destDir: '/fonts' });
-};
-
-module.exports = EmberCLIBootstrap;

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Lin Reid",
   "main": "index.js",
   "scripts": {
-    "prepublish": "mkdir -p vendor/ember-addons.bs_for_ember && cp -r bower_components/ember-addons.bs_for_ember/dist/ vendor/ember-addons.bs_for_ember/dist/",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "bower install"
   },
   "keywords": [
     "ember-addon",
@@ -18,8 +18,5 @@
     "type": "git",
     "url": "git://github.com/dockyard/ember-cli-bootstrap.git"
   },
-  "license": "MIT",
-  "dependencies": {
-    "bootstrap": "3.x"
-  }
+  "license": "MIT"
 }


### PR DESCRIPTION
I believe this PR should be used as a replacement for 617d6f52adb1016103338d689a81d648d3b0064b

Keeping the bower install is a good idea, bootstrap components shouldn't be moved into npm. And caching vendor assets in the ember-cli shim is bad.
