### PR TITLE
Option to exclude default theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,27 @@ var app = new EmberApp({
 
 module.exports = app.toTree();
 ```
+
+
+## Excluding default Bootstrap theme
+
+By default, the distributed Bootstrap theme will be imported. If you
+import a custom theme this may cause problems. You can optionally
+*exclude* the default Twitter Bootstrap theme by setting the
+`excludeBootstrapTheme` option to true in your `Brocfile.js`:
+
+```javascript
+//your-bootstrap-app/Brocfile.js
+
+/* global require, module */
+
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+var app = new EmberApp({
+  'ember-cli-bootstrap': {
+    'excludeBootstrapTheme': true
+  }
+});
+
+module.exports = app.toTree();
+```

--- a/index.js
+++ b/index.js
@@ -18,8 +18,12 @@ module.exports = {
     var javascriptsPath = path.join(emberBsPath, 'js');
     var jsFiles         = options.components ? options.components : fs.readdirSync(path.join(modulePath, javascriptsPath));
 
+    // Optionally import default bootstrap theme
+    if (!options.excludeBootstrapTheme) {
+      app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css'));
+    }
+
     // Import css from bootstrap
-    app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css'));
     app.import(path.join(bootstrapPath, 'css/bootstrap.css'));
     app.import(path.join(emberBsPath, 'css/bs-growl-notifications.min.css'));
 


### PR DESCRIPTION
I include a theme provided by http://bootswatch.com/ but the distributed Bootstrap theme that is imported by this addon causes problems. All I need to do is exclude the default Bootstrap theme. This PR adds the option `excludeBootstrapTheme` (named similarly to the JS option) and provides backwards compatibility with its default of `false`.

Looking at PR #14 there might be some need for granularity. So, I'm throwing this out there but more thought is probably needed. I'm willing to discuss other options and create PR's.
