### PR TITLE
Allow root for bower install

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "postinstall": "bower install"
+    "postinstall": "bower install --allow-root"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Useful in a docker-based CI environment
