### PR TITLE
Don't import css.map if importBootstrapCSS is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,8 +24,9 @@ module.exports = {
     }
     if (options.importBootstrapCSS !== false) {
       app.import(path.join(bootstrapPath, 'css/bootstrap.css'));
+      app.import(path.join(bootstrapPath, 'css/bootstrap.css.map'), { destDir: 'assets' });
     }
-    app.import(path.join(bootstrapPath, 'css/bootstrap.css.map'), { destDir: 'assets' });
+    
     app.import(path.join(emberBsPath, 'css/bs-growl-notifications.min.css'));
 
     // Import javascript files


### PR DESCRIPTION
Don't impor the css source map if you're not importing the css
