### PR TITLE
Several bug fixes and improvements

### DIFF
--- a/blueprints/ember-cli-bootstrap/index.js
+++ b/blueprints/ember-cli-bootstrap/index.js
@@ -8,9 +8,17 @@ module.exports = {
   afterInstall: function() {
     var addonContext = this;
 
-    return this.addBowerPackageToProject('bootstrap', '~3.3')
-      .then(function() {
+    // Ability to add multiple bower packages introduced in ember-cli 0.1.2
+    if (this.addBowerPackagesToProject) {
+      return this.addBowerPackagesToProject([
+        {name: 'bootstrap', target: '~3.3'},
+        {name: 'ember-addons.bs_for_ember', target: '~0.7.0'}
+      ]);
+    } else { // Else need to add them individually
+      return this.addBowerPackageToProject('bootstrap', '~3.3').then(function(){
         return addonContext.addBowerPackageToProject('ember-addons.bs_for_ember', '~0.7.0');
       });
+    }
+
   }
 };

--- a/index.js
+++ b/index.js
@@ -56,11 +56,5 @@ module.exports = {
       app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.ttf'), { destDir: '/fonts' });
       app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.woff'), { destDir: '/fonts' });
     }
-
-    // import bootstrap module
-    app.import(path.join('vendor/ember-cli-bootstrap/shim.js'), {
-      type: 'vendor',
-      exports: { 'bootstrap': ['default'] }
-    });
   }
 };

--- a/index.js
+++ b/index.js
@@ -28,25 +28,40 @@ module.exports = {
 
     // Import css from bootstrap
     if (options.importBootstrapTheme) {
-      app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css'));
+      app.import({
+        development: path.join(bootstrapPath, 'css/bootstrap-theme.css'),
+        production: path.join(bootstrapPath, 'css/bootstrap-theme.min.css')
+      });
     }
 
     if (options.importBootstrapCSS !== false) {
-      app.import(path.join(bootstrapPath, 'css/bootstrap.css'));
+      app.import({
+        development: path.join(bootstrapPath, 'css/bootstrap.css'),
+        production: path.join(bootstrapPath, 'css/bootstrap.min.css')
+      });
       app.import(path.join(bootstrapPath, 'css/bootstrap.css.map'), { destDir: 'assets' });
       app.import(path.join(emberBsPath, 'css/bs-growl-notifications.min.css'));
     }
 
     // Import javascript files
-    app.import(path.join(javascriptsPath, 'bs-core.max.js')); // Import bs-core first
+    app.import({
+      development: path.join(javascriptsPath, 'bs-core.max.js'),
+      production: path.join(javascriptsPath, 'bs-core.min.js')
+    }); // Import bs-core first
 
     jsFiles.forEach(function(file) {
       var fileName = file.split('.')[0];
-      app.import(path.join(javascriptsPath, fileName + '.max.js'));
+      app.import({
+        development: path.join(javascriptsPath, fileName + '.max.js'),
+        production: path.join(javascriptsPath, fileName + '.min.js')
+      });
     });
 
     if (options.importBootstrapJS) {
-      app.import(path.join(bootstrapPath, 'js/bootstrap.js'));
+      app.import({
+        development: path.join(bootstrapPath, 'js/bootstrap.js'),
+        production: path.join(bootstrapPath, 'js/bootstrap.min.js')
+      });
     }
 
     // Import glyphicons

--- a/index.js
+++ b/index.js
@@ -15,10 +15,17 @@ module.exports = {
     var bootstrapPath   = app.bowerDirectory + '/bootstrap/dist';
     var emberBsPath     = app.bowerDirectory + '/ember-addons.bs_for_ember/dist';
     var javascriptsPath = path.join(emberBsPath, 'js/');
-    var jsFiles         = options.components ? options.components : fs.readdirSync(path.join(javascriptsPath));
+
+    // Component names from options, or list of all available components
+    var jsFiles = options.components || fs.readdirSync(javascriptsPath).filter(function(fileName){
+      var fileParts = fileName.split('.');
+      return fileParts[0] != 'bs-core' && fileParts[1] == 'max'; // Limit to just one component file
+    }).map(function(fileName){
+      return fileName.split('.')[0]; // Remove the filename extensions
+    });
 
     // remove underscore from bs-popover component's template name
-    if (jsFiles.indexOf('bs-popover') > -1 || jsFiles.indexOf('bs-popover.max.js') > -1 ) {
+    if (jsFiles.indexOf('bs-popover') > -1) {
       var popoverPath = path.join(javascriptsPath, 'bs-popover.max.js');
       var data = fs.readFileSync(popoverPath, { 'encoding': 'utf8' });
       var modifiedFile = data.replace(/\/_partial-content-/g, '/partial-content-');
@@ -56,8 +63,7 @@ module.exports = {
       production: path.join(javascriptsPath, 'bs-core.min.js')
     }); // Import bs-core first
 
-    jsFiles.forEach(function(file) {
-      var fileName = file.split('.')[0];
+    jsFiles.forEach(function(fileName) {
       app.import({
         development: path.join(javascriptsPath, fileName + '.max.js'),
         production: path.join(javascriptsPath, fileName + '.min.js')

--- a/index.js
+++ b/index.js
@@ -31,7 +31,10 @@ module.exports = {
         development: path.join(bootstrapPath, 'css/bootstrap.css'),
         production: path.join(bootstrapPath, 'css/bootstrap.min.css')
       });
-      app.import(path.join(bootstrapPath, 'css/bootstrap.css.map'), { destDir: 'assets' });
+      app.import({
+        development: path.join(bootstrapPath, 'css/bootstrap.css.map'),
+        production: false
+      }, { destDir: 'assets' });
       app.import(path.join(emberBsPath, 'css/bs-growl-notifications.min.css'));
     }
 
@@ -41,7 +44,10 @@ module.exports = {
         development: path.join(bootstrapPath, 'css/bootstrap-theme.css'),
         production: path.join(bootstrapPath, 'css/bootstrap-theme.min.css')
       });
-      app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css.map'), { destDir: 'assets' });
+      app.import({
+        development: path.join(bootstrapPath, 'css/bootstrap-theme.css.map'),
+        production: false
+      }, { destDir: 'assets' });
     }
 
     // Import javascript files

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
       app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css'));
     }
 
-    if (!options.importBootstrapCSS) {
+    if (options.importBootstrapCSS !== false) {
       app.import(path.join(bootstrapPath, 'css/bootstrap.css'));
       app.import(path.join(bootstrapPath, 'css/bootstrap.css.map'), { destDir: 'assets' });
       app.import(path.join(emberBsPath, 'css/bs-growl-notifications.min.css'));
@@ -50,7 +50,7 @@ module.exports = {
     }
 
     // Import glyphicons
-    if (!options.importBootstrapFont) {
+    if (options.importBootstrapFont !== false) {
       app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.eot'), { destDir: '/fonts' });
       app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.svg'), { destDir: '/fonts' });
       app.import(path.join(bootstrapPath, 'fonts/glyphicons-halflings-regular.ttf'), { destDir: '/fonts' });

--- a/index.js
+++ b/index.js
@@ -26,14 +26,6 @@ module.exports = {
       fs.writeFileSync(popoverPath, modifiedFile, { 'encoding': 'utf8' });
     }
 
-    // Import css from bootstrap
-    if (options.importBootstrapTheme) {
-      app.import({
-        development: path.join(bootstrapPath, 'css/bootstrap-theme.css'),
-        production: path.join(bootstrapPath, 'css/bootstrap-theme.min.css')
-      });
-    }
-
     if (options.importBootstrapCSS !== false) {
       app.import({
         development: path.join(bootstrapPath, 'css/bootstrap.css'),
@@ -41,6 +33,15 @@ module.exports = {
       });
       app.import(path.join(bootstrapPath, 'css/bootstrap.css.map'), { destDir: 'assets' });
       app.import(path.join(emberBsPath, 'css/bs-growl-notifications.min.css'));
+    }
+
+    // Import css from bootstrap
+    if (options.importBootstrapTheme) {
+      app.import({
+        development: path.join(bootstrapPath, 'css/bootstrap-theme.css'),
+        production: path.join(bootstrapPath, 'css/bootstrap-theme.min.css')
+      });
+      app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css.map'), { destDir: 'assets' });
     }
 
     // Import javascript files


### PR DESCRIPTION
After working on ember-cli-bootswatch, I discovered several issues with the latest release of this addon. This PR fixes several bugs and adds some improvements:
- `importBootstrapCSS` and `importBootstrapFont` option `if` statements in `index.js` were incorrect. Basically was the opposite of the option name, fixed and also enabled backwards compatibility, if the options were not included from the projects `Brocfile.js`
- Version 0.0.13 currently does not work, error about "unknown shim.js" file. Not sure what the file is supposed to be or where it comes from so I simply removed the import. Fixes #35 
- Also `.import()` the minified version of several files for production builds. Since the bower deps include minified versions, I've typically included them.
- Removed the `.map` files from being imported in production builds. They are not needed and are not referenced in the minified stylesheets.
- Moved the theme import _after_ the standard bootstrap stylesheet. This way the theme styles will override the standard styles.
- Fixed an unreported bug where the `bootstrap_for_ember` components were being imported twice. Because there is a file for both max and min, the previous `readdir()` was including the filename twice, therefore imported twice.
- Used a new feature of ember-cli 0.1.2 that installs multiple bower deps in one call, reducing overhead. But also retain backwards compatibility by feature detecting.

I'd suggest at least fixing the shim.js error and incorrect option statements. Then release a new version since the current version of this addon is un-usable. Thanks for your consideration!
