### PR TITLE
Import template compiler for runtime compilation (working)

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
     }
 
     // Import Ember Template Compiler
-    app.import(path.join(app.bowerDirectory, 'ember', 'ember-template-compiler'));
+    app.import(path.join(app.bowerDirectory, 'ember', 'ember-template-compiler.js'));
 
     // Import css from bootstrap
     if (options.importBootstrapTheme) {

--- a/index.js
+++ b/index.js
@@ -26,6 +26,9 @@ module.exports = {
       fs.writeFileSync(popoverPath, modifiedFile, { 'encoding': 'utf8' });
     }
 
+    // Import Ember Template Compiler
+    app.import(path.join(app.bowerDirectory, 'ember', 'ember-template-compiler'));
+
     // Import css from bootstrap
     if (options.importBootstrapTheme) {
       app.import(path.join(bootstrapPath, 'css/bootstrap-theme.css'));


### PR DESCRIPTION
Resolves #39 by including the '.js' file extension when requiring the template compiler. Based on #40.  
